### PR TITLE
Added a flag to disallow unaligned DMA

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -187,6 +187,7 @@ uint32_t OverscanLeft = 0;
 uint32_t OverscanRight = 0;
 uint32_t OverscanBottom = 0;
 
+uint32_t AllowUnalignedDMA = 1;
 uint32_t LegacySm64ToolsHacks = 0;
 uint32_t RemoveFBBlackBars = 0;
 
@@ -1694,6 +1695,13 @@ void update_variables(bool startup)
          else
             pad_pak_types[3] = p4_pak;
       }
+   }
+   
+   var.key = CORE_NAME "-allow-unaligned-dma";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      AllowUnalignedDMA = !strcmp(var.value, "False") ? 0 : 1;
    }
 
    var.key = CORE_NAME "-gliden64-BilinearMode";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -871,6 +871,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "disabled"
     },
     {
+        CORE_NAME "-allow-unaligned-dma",
+        "Unaligned DMA Behaviour",
+        NULL,
+        "'Allow Unaligned' causes minor issues on Taz Express; 'Force Alignment' is accurate to N64, but breaks some romhacks.",
+        NULL,
+        NULL,
+        {
+            {"True", "Allow Unaligned"},
+            {"False", "Force Alignment"},
+            { NULL, NULL }
+        },
+        "True"
+    },
+    {
         CORE_NAME "-gliden64-viewport-hack",
         "Widescreen Hack",
         NULL,

--- a/mupen64plus-core/src/pi/pi_controller.c
+++ b/mupen64plus-core/src/pi/pi_controller.c
@@ -36,6 +36,8 @@
 
 #include <string.h>
 
+extern uint32_t AllowUnalignedDMA;
+
 enum
 {
    /* PI_STATUS - read */
@@ -56,6 +58,11 @@ static void dma_pi_read(struct pi_controller *pi)
    uint32_t rom_address;
    const uint8_t* dram;
    uint8_t* rom;
+   
+   if( !AllowUnalignedDMA ) {
+	   pi->regs[PI_CART_ADDR_REG] &= 0xfffffffe;
+	   pi->regs[PI_DRAM_ADDR_REG] &= 0xfffffffe;
+   }
 
    /* XXX: end of domain is wrong ? */
    if (pi->regs[PI_CART_ADDR_REG] >= 0x05000000 && pi->regs[PI_CART_ADDR_REG] < 0x06000000)
@@ -124,6 +131,11 @@ static void dma_pi_write(struct pi_controller *pi)
    uint32_t rom_address;
    uint8_t* dram;
    const uint8_t* rom;
+   
+   if( !AllowUnalignedDMA ) {
+	   pi->regs[PI_CART_ADDR_REG] &= 0xfffffffe;
+	   pi->regs[PI_DRAM_ADDR_REG] &= 0xfffffffe;
+   }
 
    if (pi->regs[PI_CART_ADDR_REG] < 0x10000000 && !(pi->regs[PI_CART_ADDR_REG] >= 0x06000000 && pi->regs[PI_CART_ADDR_REG] < 0x08000000))
    {


### PR DESCRIPTION
Basically the fix from here: https://github.com/mupen64plus/mupen64plus-core/pull/541
But behind a flag so it doesn't brick all old romhacks.

I might expose it as an option in Parallel Launcher, but since it's completely harmless to allow unaligned DMA in everything except that one ROM, I might just always have it set to allow unaligned DMA and only change the setting if playing that specific rom.